### PR TITLE
Fix type mismatch error message

### DIFF
--- a/src/base-type.typ
+++ b/src/base-type.typ
@@ -43,7 +43,7 @@
           it,
           scope: scope,
           ctx: ctx,
-          message: "Expected " + types.join(
+          message: "Expected " + self.types.map(repr).join(
             ", ",
             last: " or ",
           ) + ". Got " + type(it),


### PR DESCRIPTION
Functions cannot be joined, so they need to be turned into their `repr` first.