### PR TITLE
improve introspection of types

### DIFF
--- a/src/base-type.typ
+++ b/src/base-type.typ
@@ -4,6 +4,7 @@
 /// Schema generator. Provides default values for when defining custom types.
 #let base-type(
   name: "unknown",
+  description: none,
   optional: false,
   default: none,
   types: (),
@@ -21,6 +22,7 @@
   return (
     valkyrie-type: true,
     name: name,
+    description: if (description != none){ description } else { name },
     optional: optional,
     default: default,
     types: types,

--- a/src/schemas/enumerations.typ
+++ b/src/schemas/enumerations.typ
@@ -1,7 +1,7 @@
 #import "../types.typ" as z;
 
 #let papersize = z.choice.with(
-  name: "paper size",
+  description: "paper size",
   (
     "a0",
     "a1",

--- a/src/types/array.typ
+++ b/src/types/array.typ
@@ -18,7 +18,8 @@
   assert-positive-type(max, types: (int,), name: "Maximum length")
 
   base-type(
-    name: "array[" + (descendents-schema.name) + "]",
+    name: name,
+    description: name + "[" + (descendents-schema.description) + "]",
     default: (),
     types: (array-type,),
     ..args.named(),

--- a/src/types/dictionary.typ
+++ b/src/types/dictionary.typ
@@ -10,22 +10,19 @@
 /// -> schema
 #let dictionary(
   dictionary-schema,
+  name: "dictionary",
   default: (:),
-  optional: false,
-  assertions: (),
   pre-transform: (self, it) => it,
-  post-transform: (self, it) => it,
   aliases: (:),
+  ..args,
 ) = {
 
   assert-base-type-dictionary(dictionary-schema)
 
   base-type(
-    name: "dictionary",
-    optional: optional,
+    name: name,
     default: default,
     types: (dictionary-type,),
-    assertions: assertions,
     pre-transform: (self, it) => {
       it = pre-transform(self, it)
       for (src, dst) in aliases {
@@ -37,7 +34,7 @@
       }
       return it
     },
-    post-transform: post-transform,
+    ..args.named()
   ) + (
     dictionary-schema: dictionary-schema,
     handle-descendents: (self, it, ctx: z-ctx(), scope: ()) => {

--- a/src/types/logical.typ
+++ b/src/types/logical.typ
@@ -17,7 +17,8 @@
   assert-base-type-array(args.pos(), scope: ("arguments",))
 
   base-type(
-    name: "[" + args.pos().map(it => it.name).join(", ", last: " or ") + "]",
+    name: "either",
+    description: "[" + args.pos().map(it => it.name).join(", ", last: " or ") + "]",
     ..args.named(),
   ) + (
     strict: strict,
@@ -36,7 +37,7 @@
       }
 
       let message = (
-        "Type failed to match any of possible options: " + self.options.map(it => it.name).join(
+        "Type failed to match any of possible options: " + self.options.map(it => it.description).join(
           ", ",
           last: " or ",
         ) + ". Got " + type(it)

--- a/src/types/number.typ
+++ b/src/types/number.typ
@@ -30,5 +30,5 @@
   )
 }
 
-#let integer = number.with(name: "integer", types: (int,))
-#let floating-point = number.with(name: "float", types: (float,))
+#let integer = number.with(description: "integer", types: (int,))
+#let floating-point = number.with(description: "float", types: (float,))

--- a/src/types/string.typ
+++ b/src/types/string.typ
@@ -39,7 +39,7 @@
 }
 
 #let email = string.with(
-  name: "email",
+  description: "email",
   assertions: (
     matches(
       regex("^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+(\.[a-zA-Z0-9-]{2,3}){1,2}$"),
@@ -49,7 +49,7 @@
 );
 
 #let ip = string.with(
-  name: "ip",
+  description: "ip",
   assertions: (
     matches(
       regex("^(?:(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\.){3}(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])$"),

--- a/src/types/string.typ
+++ b/src/types/string.typ
@@ -7,8 +7,6 @@
 /// Valkyrie schema generator for strings
 ///
 /// -> schema
-#let string = base-type.with(name: "string", types: (str,))
-
 #let string(
   assertions: (),
   min: none,


### PR DESCRIPTION
This PR adds a `description` field on base-type, which serves to take the descriptive burden off `name` so that it can more properly be used to identify types for the purposes of rendering them.

For schema generators already in the code base where such specializations do not warrant a distinct `name` (string derivatives and number derivatives), the new `description` field is used instead.

For schema generators for more complicated types (array, either, dictionary) `name` is constant and `description` takes the burden of describing child schema.

The codebase has been reviewed for any opportunities to include information in the schema itself rather than guess what type it is (i.e., make schemas more characteristic). I think I managed to get them all, but in reviewing, I do think the `choice` type might be better reworked into a type more properly than through assertions.

To do: 
- [ ] Update changelog to reflect any breaking changes
