### PR TITLE
Fix "Cannot add string and type"

### DIFF
--- a/src/assertions-util.typ
+++ b/src/assertions-util.typ
@@ -31,10 +31,10 @@
 #let assert-types(var, types: (), default: none, name: "") = {
   assert(
     type(var) in (type(default), ..types),
-    message: "" + name + " must be of type " + types.join(
+    message: "" + name + " must be of type " + types.map(str).join(
       ", ",
       last: " or ",
-    ) + ". Got " + type(var),
+    ) + ". Got " + str(type(var)),
   )
 }
 


### PR DESCRIPTION
Fixes the error "Cannot add string and type" which I got when importing the library using the latest development version (Jan 13, 2025) on https://typst.app
