### PR TITLE
Typst 0.13 compatibility: Fix 1 more error and 2 warnings

### DIFF
--- a/src/assertions.typ
+++ b/src/assertions.typ
@@ -1,4 +1,4 @@
-#import "./assertions/length.typ" as length
+#import "./assertions/length.typ"
 #import "./assertions/comparative.typ": min, max, eq, neq
 #import "./assertions/string.typ": *
 

--- a/src/base-type.typ
+++ b/src/base-type.typ
@@ -48,7 +48,7 @@
           message: "Expected " + self.types.map(repr).join(
             ", ",
             last: " or ",
-          ) + ". Got " + type(it),
+          ) + ". Got " + str(type(it)),
         )
         return false
       }

--- a/src/lib.typ
+++ b/src/lib.typ
@@ -4,7 +4,7 @@
 #import "assertions-util.typ" as advanced
 #import "assertions.typ" as assert
 #import "coercions.typ" as coerce
-#import "schemas.typ" as schemas
+#import "schemas.typ"
 
 #let parse(
   object,


### PR DESCRIPTION
- Fix another error "Cannot add type and string"
- Fix two warning "Unnecessary import rename to same name"

For https://github.com/typst-community/valkyrie/issues/52